### PR TITLE
add shutdown command

### DIFF
--- a/includes/discord.h
+++ b/includes/discord.h
@@ -2,6 +2,7 @@
 
 #include <openssl/ssl.h>
 #include <pthread.h>
+#include <semaphore.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <time.h>
@@ -31,8 +32,9 @@ struct _ttc_discord_ctx_s {
 	char *session_id;
 	char *gateway_url;
 	uint64_t sequence;
-	pthread_t read_thread, heart_thread;
-	int running;
+	pthread_t read_thread, heart_thread, cli_thread;
+	// this semaphore is locked while the bot is running. Unlocking it stops the bot safely
+	sem_t finish_sem;
 
 	cmd_listeners_t *command_callbacks;
 	uint64_t callbacks;

--- a/includes/ttc-discord/discord.h
+++ b/includes/ttc-discord/discord.h
@@ -71,3 +71,4 @@ typedef struct command {
 int ttc_discord_run(ttc_discord_ctx_t *ctx);
 void ttc_discord_ctx_destroy(ttc_discord_ctx_t *ctx);
 ttc_discord_ctx_t *ttc_discord_ctx_create(char *token);
+void ttc_discord_stop_bot(ttc_discord_ctx_t *ctx);

--- a/src/command.c
+++ b/src/command.c
@@ -1,3 +1,4 @@
+#include "discord.h"
 #include "ttc-discord/api.h"
 #include "ttc-discord/gateway.h"
 #include <stdint.h>
@@ -417,4 +418,13 @@ void timeout_handle(ttc_discord_interaction_t *interaction, ttc_discord_ctx_t *c
 		ttc_discord_interaction_loading_respond(ctx, "Unable to timeout user!", buf, 0xff0000,
 																						interaction);
 	}
+}
+
+void shutdown_handle(ttc_discord_interaction_t *interaction, ttc_discord_ctx_t *ctx,
+										 const char *url) {
+
+	ttc_discord_interaction_loading(ctx, url);
+	ttc_discord_interaction_loading_respond(ctx, "Bot shutting down!", "The bot will now shut down",
+																					0x00ff00, interaction);
+	ttc_discord_stop_bot(ctx);
 }

--- a/src/command.h
+++ b/src/command.h
@@ -10,3 +10,5 @@ void pardon_handle(ttc_discord_interaction_t *interaction, ttc_discord_ctx_t *ct
 void ban_handle(ttc_discord_interaction_t *interaction, ttc_discord_ctx_t *ctx, const char *url);
 void timeout_handle(ttc_discord_interaction_t *interaction, ttc_discord_ctx_t *ctx,
 										const char *url);
+void shutdown_handle(ttc_discord_interaction_t *interaction, ttc_discord_ctx_t *ctx,
+										 const char *url);

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 #include <ttc-discord/moderation.h>
 #include <ttc-discord/ui.h>
 #include <ttc-log.h>
+#include <unistd.h>
 
 #include "command.h"
 #include "components.h"
@@ -133,6 +134,16 @@ static command_t timeout = {.name = "timeout",
 																									 DISCORD_PERMISSION_BAN |
 																									 DISCORD_PERMISSION_KICK};
 
+static command_t shutdown_cmd = {.name = "shutdown",
+																 .description = "turn off the bot",
+																 .type = 1,
+																 .options = NULL,
+																 .option_count = 0,
+																 .allow_in_dms =
+																		 false, // to ensure the ADMIN permission is at least checked by
+																						// Discord. We should add a better check though
+																 .default_permissions = DISCORD_PERMISSION_ADMIN};
+
 int ttc_discord_create_text_input(ttc_discord_ctx_t *ctx, uint32_t type, const char *menu_id,
 																	uint64_t channel);
 
@@ -146,6 +157,10 @@ int main() {
 	discord_create_application_command(&pardon, discord, pardon_handle);
 	discord_create_application_command(&ban, discord, ban_handle);
 	discord_create_application_command(&timeout, discord, timeout_handle);
+	// TODO: Use better method/approach to prevent being ratelimited while registering commands
+	// globally
+	sleep(10);
+	discord_create_application_command(&shutdown_cmd, discord, shutdown_handle);
 
 	ttc_discord_create_select_menu(discord, 6, "role_select", 913091622592458833, 25);
 
@@ -156,5 +171,6 @@ int main() {
 
 	ttc_discord_ctx_destroy(discord);
 	ttc_log_deinit_file();
+
 	return 0;
 }


### PR DESCRIPTION
this commit adds a shutdown command. To implement this the CLI was moved into a own thread and the stopping mechanism is implemented via a semaphore that is locked until the bot should stop. When it becomes unlocked it will get locked by the main thread which will then safely end all threads.

since `getline` can allocate memory before blocking a cleanup handles was also added for the CLI thread